### PR TITLE
Add option for node envelopes

### DIFF
--- a/include/osm2ttl/config/Config.h
+++ b/include/osm2ttl/config/Config.h
@@ -47,6 +47,7 @@ struct Config {
 
   // Select amount to dump
   bool addAreaEnvelope = false;
+  bool addNodeEnvelope = false;
   bool addSortMetadata = true;
   bool addWayEnvelope = false;
   bool addWayMetadata = false;

--- a/include/osm2ttl/config/Constants.h
+++ b/include/osm2ttl/config/Constants.h
@@ -165,6 +165,14 @@ const static inline std::string ADD_AREA_ENVELOPE_RATIO_OPTION_LONG =
 const static inline std::string ADD_AREA_ENVELOPE_RATIO_OPTION_HELP =
     "Add area/envelope ratio to areas";
 
+const static inline std::string ADD_NODE_ENVELOPE_INFO =
+    "Adding node envelopes";
+const static inline std::string ADD_NODE_ENVELOPE_OPTION_SHORT = "";
+const static inline std::string ADD_NODE_ENVELOPE_OPTION_LONG =
+    "add-node-envelope";
+const static inline std::string ADD_NODE_ENVELOPE_OPTION_HELP =
+    "Add envelope to nodes";
+
 const static inline std::string ADD_WAY_ENVELOPE_INFO = "Adding way envelopes";
 const static inline std::string ADD_WAY_ENVELOPE_OPTION_SHORT = "";
 const static inline std::string ADD_WAY_ENVELOPE_OPTION_LONG =

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -70,6 +70,11 @@ std::string osm2ttl::config::Config::getInfo(std::string_view prefix) const {
     }
     if (noNodeFacts) {
       oss << "\n" << prefix << osm2ttl::config::constants::NO_NODE_FACTS_INFO;
+    } else {
+      if (addNodeEnvelope) {
+        oss << "\n"
+            << prefix << osm2ttl::config::constants::ADD_NODE_ENVELOPE_INFO;
+      }
     }
     if (noRelationFacts) {
       oss << "\n"
@@ -257,6 +262,10 @@ void osm2ttl::config::Config::fromArgs(int argc, char** argv) {
       osm2ttl::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_SHORT,
       osm2ttl::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_LONG,
       osm2ttl::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_HELP);
+  auto addNodeEnvelopeOp = op.add<popl::Switch>(
+      osm2ttl::config::constants::ADD_NODE_ENVELOPE_OPTION_SHORT,
+      osm2ttl::config::constants::ADD_NODE_ENVELOPE_OPTION_LONG,
+      osm2ttl::config::constants::ADD_NODE_ENVELOPE_OPTION_HELP);
   auto addWayEnvelopeOp = op.add<popl::Switch>(
       osm2ttl::config::constants::ADD_WAY_ENVELOPE_OPTION_SHORT,
       osm2ttl::config::constants::ADD_WAY_ENVELOPE_OPTION_LONG,
@@ -394,6 +403,7 @@ void osm2ttl::config::Config::fromArgs(int argc, char** argv) {
     // Select amount to dump
     addAreaEnvelope = addAreaEnvelopeOp->is_set();
     addAreaEnvelopeRatio = addAreaEnvelopeRatioOp->is_set();
+    addNodeEnvelope = addNodeEnvelopeOp->is_set();
     addWayEnvelope = addWayEnvelopeOp->is_set();
     addWayMetadata = addWayMetaDataOp->is_set();
     addWayNodeOrder = addWayNodeOrderOp->is_set();

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -91,6 +91,10 @@ void osm2ttl::osm::FactHandler<W>::node(const osm2ttl::osm::Node& node) {
                      node.geom());
 
   writeTagList(s, node.tags());
+
+  if (_config.addNodeEnvelope) {
+    writeBox(s, osm2ttl::ttl::constants::IRI__OSM_ENVELOPE, node.envelope());
+  }
 }
 
 // ____________________________________________________________________________

--- a/tests/config/Config.cpp
+++ b/tests/config/Config.cpp
@@ -872,6 +872,17 @@ TEST(CONFIG_Config, getInfoAddAreaEnvelopeRatio) {
 }
 
 // ____________________________________________________________________________
+TEST(CONFIG_Config, getInfoAddNodeEnvelope) {
+  osm2ttl::config::Config config;
+  assertDefaultConfig(config);
+  config.addNodeEnvelope = true;
+
+  const std::string res = config.getInfo("");
+  ASSERT_THAT(res, ::testing::HasSubstr(
+                       osm2ttl::config::constants::ADD_NODE_ENVELOPE_INFO));
+}
+
+// ____________________________________________________________________________
 TEST(CONFIG_Config, getInfoAddWayEnvelope) {
   osm2ttl::config::Config config;
   assertDefaultConfig(config);

--- a/tests/config/Config.cpp
+++ b/tests/config/Config.cpp
@@ -42,6 +42,7 @@ void assertDefaultConfig(const osm2ttl::config::Config& config) {
 
   ASSERT_FALSE(config.addAreaEnvelope);
   ASSERT_FALSE(config.addAreaEnvelopeRatio);
+  ASSERT_FALSE(config.addNodeEnvelope);
   ASSERT_TRUE(config.addSortMetadata);
   ASSERT_FALSE(config.addWayEnvelope);
   ASSERT_FALSE(config.addWayNodeOrder);
@@ -544,6 +545,22 @@ TEST(CONFIG_Config, fromArgsAddAreaEnvelopeRatioLong) {
   config.fromArgs(argc, argv);
   ASSERT_EQ("", config.output.string());
   ASSERT_TRUE(config.addAreaEnvelopeRatio);
+}
+
+// ____________________________________________________________________________
+TEST(CONFIG_Config, fromArgsAddNodeEnvelopeLong) {
+  osm2ttl::config::Config config;
+  assertDefaultConfig(config);
+
+  osm2ttl::util::CacheFile cf("/tmp/dummyInput");
+  auto arg =
+      "--" + osm2ttl::config::constants::ADD_NODE_ENVELOPE_OPTION_LONG;
+  const int argc = 3;
+  char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
+                      const_cast<char*>("/tmp/dummyInput")};
+  config.fromArgs(argc, argv);
+  ASSERT_EQ("", config.output.string());
+  ASSERT_TRUE(config.addNodeEnvelope);
 }
 
 // ____________________________________________________________________________

--- a/tests/config/Config.cpp
+++ b/tests/config/Config.cpp
@@ -261,7 +261,7 @@ TEST(CONFIG_Config, fromArgsUnkonwOption) {
   ASSERT_EXIT(
       config.fromArgs(argc, argv),
       ::testing::ExitedWithCode(osm2ttl::config::ExitCode::UNKNOWN_ARGUMENT),
-      "^Unknown argument(s) specified:");
+      "^Unknown argument");
 }
 
 // ____________________________________________________________________________


### PR DESCRIPTION
This PR adds a new command line option `--add-node-envelope` which stores the bounding box for each `node`. This bounding box repeats the same coordinates multiple times.