### PR TITLE
Add _nonarea suffix to ogc:contains and ogc:intersects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,28 +79,28 @@ docker-dirs:
 
 docker-fr: docker-dirs input/freiburg-regbez-latest.osm.pbf
 	${DOCKER} build -t osm2ttl .
-	${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/freiburg-regbez-latest.osm.pbf -o /output/freiburg-regbez-latest.osm.ttl -t /scratch/ --add-inverse-relation-direction
+	${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/freiburg-regbez-latest.osm.pbf -o /output/freiburg-regbez-latest.osm.ttl -t /scratch/
 
 docker-bw: docker-dirs input/baden-wuerttemberg-latest.osm.pbf
 	${DOCKER} build -t osm2ttl .
-	${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/baden-wuerttemberg-latest.osm.pbf -o /output/baden-wuerttemberg-latest.osm.ttl -t /scratch/ --add-inverse-relation-direction
+	${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/baden-wuerttemberg-latest.osm.pbf -o /output/baden-wuerttemberg-latest.osm.ttl -t /scratch/
 
 docker-de: docker-dirs input/germany-latest.osm.pbf
 	${DOCKER} build -t osm2ttl .
-	${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/germany-latest.osm.pbf -o /output/germany-latest.osm.ttl -t /scratch/ --add-inverse-relation-direction
+	${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/germany-latest.osm.pbf -o /output/germany-latest.osm.ttl -t /scratch/
 
 docker-eu: docker-dirs input/europe-latest.osm.pbf
 	${DOCKER} build -t osm2ttl .
-	${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/europe-latest.osm.pbf -o /output/europe-latest.osm.ttl -t /scratch/ --add-inverse-relation-direction
+	${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/europe-latest.osm.pbf -o /output/europe-latest.osm.ttl -t /scratch/
 
 docker-pl: docker-dirs input/planet-latest.osm.pbf
 	${DOCKER} build -t osm2ttl .
-	${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/planet-latest.osm.pbf -o /output/planet-latest.osm.ttl -t /scratch/ --add-inverse-relation-direction
+	${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/planet-latest.osm.pbf -o /output/planet-latest.osm.ttl -t /scratch/
 
 docker-fr-ratios: docker-dirs input/freiburg-regbez-latest.osm.pbf
 	${DOCKER} build -t osm2ttl .
-	for R in "-1" "0.001" "0.01" "0.1" "0.2" "0.25" "0.5" "0.75" "0.9" "1.0"; do ${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/freiburg-regbez-latest.osm.pbf -o /output/freiburg-regbez-latest.osm.ttl -t /scratch/ --add-inverse-relation-direction --minimal-area-envelope-ratio $$R --no-node-geometric-relations --no-way-geometric-relations; done
+	for R in "-1" "0.001" "0.01" "0.1" "0.2" "0.25" "0.5" "0.75" "0.9" "1.0"; do ${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/freiburg-regbez-latest.osm.pbf -o /output/freiburg-regbez-latest.osm.ttl -t /scratch/ --minimal-area-envelope-ratio $$R --no-node-geometric-relations --no-way-geometric-relations; done
 
 docker-bw-ratios: docker-dirs input/baden-wuerttemberg-latest.osm.pbf
 	${DOCKER} build -t osm2ttl .
-	for R in "-1" "0.001" "0.01" "0.1" "0.2" "0.25" "0.5" "0.75" "0.9" "1.0"; do ${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/baden-wuerttemberg-latest.osm.pbf -o /output/baden-wuerttemberg-latest.ttl -t /scratch/ --add-inverse-relation-direction --minimal-area-envelope-ratio $$R --no-node-geometric-relations --no-way-geometric-relations; done
+	for R in "-1" "0.001" "0.01" "0.1" "0.2" "0.25" "0.5" "0.75" "0.9" "1.0"; do ${DOCKER} run --rm -v `pwd`/input/:/input/ -v `pwd`/output/:/output/ -v `pwd`/scratch/:/scratch/ -it osm2ttl /input/baden-wuerttemberg-latest.osm.pbf -o /output/baden-wuerttemberg-latest.ttl -t /scratch/ --minimal-area-envelope-ratio $$R --no-node-geometric-relations --no-way-geometric-relations; done

--- a/include/osm2ttl/config/Config.h
+++ b/include/osm2ttl/config/Config.h
@@ -47,7 +47,6 @@ struct Config {
 
   // Select amount to dump
   bool addAreaEnvelope = false;
-  bool addInverseRelationDirection = false;
   bool addSortMetadata = true;
   bool addWayEnvelope = false;
   bool addWayMetadata = false;

--- a/include/osm2ttl/config/Constants.h
+++ b/include/osm2ttl/config/Constants.h
@@ -187,14 +187,6 @@ const static inline std::string ADD_WAY_NODE_ORDER_OPTION_LONG =
 const static inline std::string ADD_WAY_NODE_ORDER_OPTION_HELP =
     "Add information about the node members in ways";
 
-const static inline std::string ADD_INVERSE_RELATION_DIRECTION_INFO =
-    "Adding ogc:contained_by and ogc:intersected_by";
-const static inline std::string ADD_INVERSE_RELATION_DIRECTION_SHORT = "";
-const static inline std::string ADD_INVERSE_RELATION_DIRECTION_LONG =
-    "add-inverse-relation-direction";
-const static inline std::string ADD_INVERSE_RELATION_DIRECTION_HELP =
-    "Store locations on disk - slower but reduced ram usage";
-
 const static inline std::string ADMIN_RELATIONS_ONLY_INFO =
     "Only handling nodes and relations with \"admin-level\" tag";
 const static inline std::string ADMIN_RELATIONS_ONLY_OPTION_SHORT = "";

--- a/include/osm2ttl/ttl/Constants.h
+++ b/include/osm2ttl/ttl/Constants.h
@@ -40,14 +40,10 @@ const static inline std::string NAMESPACE__XML_SCHEMA = "xsd";
 inline std::string IRI__GEOSPARQL__HAS_GEOMETRY;
 inline std::string IRI__GEOSPARQL__WKT_LITERAL;
 
-inline std::string IRI__OGC_CONTAINS;
-inline std::string IRI__OGC_CONTAINED_BY;
+inline std::string IRI__OGC_CONTAINS_NONAREA;
 inline std::string IRI__OGC_CONTAINS_AREA;
-inline std::string IRI__OGC_CONTAINED_BY_AREA;
-inline std::string IRI__OGC_INTERSECTS;
-inline std::string IRI__OGC_INTERSECTED_BY;
+inline std::string IRI__OGC_INTERSECTS_NONAREA;
 inline std::string IRI__OGC_INTERSECTS_AREA;
-inline std::string IRI__OGC_INTERSECTED_BY_AREA;
 
 inline std::string IRI__OSM_META__POS;
 inline std::string IRI__OSMWAY_ISCLOSED;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -108,11 +108,11 @@ std::string osm2ttl::config::Config::getInfo(std::string_view prefix) const {
           << prefix << osm2ttl::config::constants::SEMICOLON_TAG_KEYS_INFO;
       std::vector<std::string> keys;
       keys.reserve(semicolonTagKeys.size());
-      for (auto key : semicolonTagKeys) {
+      for (const auto &key : semicolonTagKeys) {
         keys.push_back(key);
       }
       std::sort(keys.begin(), keys.end());
-      for (auto key : keys) {
+      for (const auto &key : keys) {
         oss << "\n" << prefix << prefix << key;
       }
     }
@@ -136,11 +136,6 @@ std::string osm2ttl::config::Config::getInfo(std::string_view prefix) const {
     if (noWayGeometricRelations) {
       oss << "\n"
           << prefix << osm2ttl::config::constants::NO_WAY_GEOM_RELATIONS_INFO;
-    }
-    if (addInverseRelationDirection) {
-      oss << "\n"
-          << prefix
-          << osm2ttl::config::constants::ADD_INVERSE_RELATION_DIRECTION_INFO;
     }
     if (simplifyGeometries > 0) {
       oss << "\n"
@@ -274,11 +269,6 @@ void osm2ttl::config::Config::fromArgs(int argc, char** argv) {
       osm2ttl::config::constants::ADD_WAY_NODE_ORDER_OPTION_SHORT,
       osm2ttl::config::constants::ADD_WAY_NODE_ORDER_OPTION_LONG,
       osm2ttl::config::constants::ADD_WAY_NODE_ORDER_OPTION_HELP);
-  auto addInverseRelationDirectionOp =
-      op.add<popl::Switch, popl::Attribute::advanced>(
-          osm2ttl::config::constants::ADD_INVERSE_RELATION_DIRECTION_SHORT,
-          osm2ttl::config::constants::ADD_INVERSE_RELATION_DIRECTION_LONG,
-          osm2ttl::config::constants::ADD_INVERSE_RELATION_DIRECTION_HELP);
   auto adminRelationsOnlyOp = op.add<popl::Switch>(
       osm2ttl::config::constants::ADMIN_RELATIONS_ONLY_OPTION_SHORT,
       osm2ttl::config::constants::ADMIN_RELATIONS_ONLY_OPTION_LONG,
@@ -395,7 +385,6 @@ void osm2ttl::config::Config::fromArgs(int argc, char** argv) {
     // Select amount to dump
     addAreaEnvelope = addAreaEnvelopeOp->is_set();
     addAreaEnvelopeRatio = addAreaEnvelopeRatioOp->is_set();
-    addInverseRelationDirection = addInverseRelationDirectionOp->is_set();
     addWayEnvelope = addWayEnvelopeOp->is_set();
     addWayMetadata = addWayMetaDataOp->is_set();
     addWayNodeOrder = addWayNodeOrderOp->is_set();

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -68,22 +68,14 @@ osm2ttl::ttl::Writer<T>::Writer(const osm2ttl::config::Config& config,
       generateIRI(osm2ttl::ttl::constants::NAMESPACE__GEOSPARQL, "hasGeometry");
   osm2ttl::ttl::constants::IRI__GEOSPARQL__WKT_LITERAL =
       generateIRI(osm2ttl::ttl::constants::NAMESPACE__GEOSPARQL, "wktLiteral");
-  osm2ttl::ttl::constants::IRI__OGC_CONTAINS =
-      generateIRI(osm2ttl::ttl::constants::NAMESPACE__OPENGIS, "contains");
-  osm2ttl::ttl::constants::IRI__OGC_CONTAINED_BY =
-      generateIRI(osm2ttl::ttl::constants::NAMESPACE__OPENGIS, "contained_by");
   osm2ttl::ttl::constants::IRI__OGC_CONTAINS_AREA =
       generateIRI(osm2ttl::ttl::constants::NAMESPACE__OPENGIS, "contains_area");
-  osm2ttl::ttl::constants::IRI__OGC_CONTAINED_BY_AREA = generateIRI(
-      osm2ttl::ttl::constants::NAMESPACE__OPENGIS, "contained_by_area");
-  osm2ttl::ttl::constants::IRI__OGC_INTERSECTS =
-      generateIRI(osm2ttl::ttl::constants::NAMESPACE__OPENGIS, "intersects");
-  osm2ttl::ttl::constants::IRI__OGC_INTERSECTED_BY = generateIRI(
-      osm2ttl::ttl::constants::NAMESPACE__OPENGIS, "intersected_by");
+  osm2ttl::ttl::constants::IRI__OGC_CONTAINS_NONAREA = generateIRI(
+      osm2ttl::ttl::constants::NAMESPACE__OPENGIS, "contains_nonarea");
   osm2ttl::ttl::constants::IRI__OGC_INTERSECTS_AREA = generateIRI(
       osm2ttl::ttl::constants::NAMESPACE__OPENGIS, "intersects_area");
-  osm2ttl::ttl::constants::IRI__OGC_INTERSECTED_BY_AREA = generateIRI(
-      osm2ttl::ttl::constants::NAMESPACE__OPENGIS, "intersected_by_area");
+  osm2ttl::ttl::constants::IRI__OGC_INTERSECTS_NONAREA = generateIRI(
+      osm2ttl::ttl::constants::NAMESPACE__OPENGIS, "intersects_nonarea");
   osm2ttl::ttl::constants::IRI__OSM_META__POS =
       generateIRI(osm2ttl::ttl::constants::NAMESPACE__OSM_META, "pos");
   osm2ttl::ttl::constants::IRI__OSMWAY_ISCLOSED =

--- a/tests/E2E.cpp
+++ b/tests/E2E.cpp
@@ -537,32 +537,32 @@ TEST(E2E, building51NT) {
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#intersects> "
+                  "<http://www.opengis.net/rdf#intersects_nonarea> "
                   "<https://www.openstreetmap.org/node/2110601105> .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#contains> "
+                  "<http://www.opengis.net/rdf#contains_nonarea> "
                   "<https://www.openstreetmap.org/node/2110601105> .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#intersects> "
+                  "<http://www.opengis.net/rdf#intersects_nonarea> "
                   "<https://www.openstreetmap.org/node/2110601134> .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#contains> "
+                  "<http://www.opengis.net/rdf#contains_nonarea> "
                   "<https://www.openstreetmap.org/node/2110601134> .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#intersects> "
+                  "<http://www.opengis.net/rdf#intersects_nonarea> "
                   "<https://www.openstreetmap.org/node/5190342871> .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#contains> "
+                  "<http://www.opengis.net/rdf#contains_nonarea> "
                   "<https://www.openstreetmap.org/node/5190342871> .\n"));
 
   // Reset std::cerr and std::cout
@@ -681,24 +681,30 @@ TEST(E2E, building51TTL) {
               ::testing::HasSubstr(
                   "smway:98284318 geo:hasGeometry \"MULTIPOLYGON(((7"));
   ASSERT_THAT(printedData, ::testing::HasSubstr("0)))\"^^geo:wktLiteral .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:intersects osmnode:2110601105 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:contains osmnode:2110601105 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:intersects osmnode:2110601134 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:contains osmnode:2110601134 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:intersects osmnode:5190342871 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:contains osmnode:5190342871 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601105 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:contains_nonarea osmnode:2110601105 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601134 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:contains_nonarea osmnode:2110601134 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:intersects_nonarea osmnode:5190342871 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:contains_nonarea osmnode:5190342871 .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -816,24 +822,30 @@ TEST(E2E, building51QLEVER) {
               ::testing::HasSubstr(
                   "smway:98284318 geo:hasGeometry \"MULTIPOLYGON(((7"));
   ASSERT_THAT(printedData, ::testing::HasSubstr("0)))\"^^geo:wktLiteral .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:intersects osmnode:2110601105 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:contains osmnode:2110601105 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:intersects osmnode:2110601134 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:contains osmnode:2110601134 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:intersects osmnode:5190342871 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:contains osmnode:5190342871 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601105 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:contains_nonarea osmnode:2110601105 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601134 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:contains_nonarea osmnode:2110601134 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:intersects_nonarea osmnode:5190342871 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:contains_nonarea osmnode:5190342871 .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -1089,24 +1101,30 @@ TEST(E2E, building51inTF) {
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "osmway:4498466 ogc:intersects_area osmway:98284318 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:intersects osmnode:2110601105 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:contains osmnode:2110601105 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:intersects osmnode:2110601134 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:contains osmnode:2110601134 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:intersects osmnode:5190342871 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:98284318 ogc:contains osmnode:5190342871 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601105 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:contains_nonarea osmnode:2110601105 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601134 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:contains_nonarea osmnode:2110601134 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:intersects_nonarea osmnode:5190342871 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 ogc:contains_nonarea osmnode:5190342871 .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);

--- a/tests/config/Config.cpp
+++ b/tests/config/Config.cpp
@@ -42,7 +42,6 @@ void assertDefaultConfig(const osm2ttl::config::Config& config) {
 
   ASSERT_FALSE(config.addAreaEnvelope);
   ASSERT_FALSE(config.addAreaEnvelopeRatio);
-  ASSERT_FALSE(config.addInverseRelationDirection);
   ASSERT_TRUE(config.addSortMetadata);
   ASSERT_FALSE(config.addWayEnvelope);
   ASSERT_FALSE(config.addWayNodeOrder);
@@ -117,7 +116,7 @@ TEST(CONFIG_Config, fromArgsHelpAdvanced) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_EXIT(config.fromArgs(argc, argv),
               ::testing::ExitedWithCode(osm2ttl::config::ExitCode::SUCCESS),
-              "--add-inverse-relation-direction");
+              osm2ttl::config::constants::NO_GEOM_RELATIONS_OPTION_HELP);
 }
 
 // ____________________________________________________________________________
@@ -526,22 +525,6 @@ TEST(CONFIG_Config, fromArgsAddAreaEnvelopeRatioLong) {
   config.fromArgs(argc, argv);
   ASSERT_EQ("", config.output.string());
   ASSERT_TRUE(config.addAreaEnvelopeRatio);
-}
-
-// ____________________________________________________________________________
-TEST(CONFIG_Config, fromArgsAddInverseRelationDirectionLong) {
-  osm2ttl::config::Config config;
-  assertDefaultConfig(config);
-
-  osm2ttl::util::CacheFile cf("/tmp/dummyInput");
-  auto arg =
-      "--" + osm2ttl::config::constants::ADD_INVERSE_RELATION_DIRECTION_LONG;
-  const int argc = 3;
-  char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
-                      const_cast<char*>("/tmp/dummyInput")};
-  config.fromArgs(argc, argv);
-  ASSERT_EQ("", config.output.string());
-  ASSERT_TRUE(config.addInverseRelationDirection);
 }
 
 // ____________________________________________________________________________
@@ -990,19 +973,6 @@ TEST(CONFIG_Config, getInfoWayGeomRelations) {
   const std::string res = config.getInfo("");
   ASSERT_THAT(res, ::testing::HasSubstr(
                        osm2ttl::config::constants::NO_WAY_GEOM_RELATIONS_INFO));
-}
-
-// ____________________________________________________________________________
-TEST(CONFIG_Config, getInfoAddInverseRelationDirection) {
-  osm2ttl::config::Config config;
-  assertDefaultConfig(config);
-  config.addInverseRelationDirection = true;
-
-  const std::string res = config.getInfo("");
-  ASSERT_THAT(
-      res,
-      ::testing::HasSubstr(
-          osm2ttl::config::constants::ADD_INVERSE_RELATION_DIRECTION_INFO));
 }
 
 // ____________________________________________________________________________

--- a/tests/osm/GeometryHandler.cpp
+++ b/tests/osm/GeometryHandler.cpp
@@ -1440,9 +1440,9 @@ TEST(OSM_GeometryHandler, dumpUnnamedAreaRelationsSimpleIntersects) {
                            "                           contains: 3 contains "
                            "envelope: 1 yes: 1\n"));
   ASSERT_EQ(
-      "osmway:11 ogc:intersects osmrel:15 .\n"
-      "osmway:13 ogc:intersects osmrel:15 .\n"
-      "osmway:12 ogc:contains osmrel:15 .\n",
+      "osmway:11 ogc:intersects_nonarea osmrel:15 .\n"
+      "osmway:13 ogc:intersects_nonarea osmrel:15 .\n"
+      "osmway:12 ogc:contains_nonarea osmrel:15 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -1563,8 +1563,8 @@ TEST(OSM_GeometryHandler, dumpUnnamedAreaRelationsSimpleContainsOnly) {
                            "                           contains: 1 contains "
                            "envelope: 1 yes: 1\n"));
   ASSERT_EQ(
-      "osmway:11 ogc:intersects osmrel:15 .\n"
-      "osmway:11 ogc:contains osmrel:15 .\n",
+      "osmway:11 ogc:intersects_nonarea osmrel:15 .\n"
+      "osmway:11 ogc:contains_nonarea osmrel:15 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -1846,8 +1846,8 @@ TEST(OSM_GeometryHandler, dumpNodeRelationsSimpleIntersects) {
                   "                           1 checks performed\n"
                   "                           contains: 1 yes: 1\n"));
   ASSERT_EQ(
-      "osmway:13 ogc:intersects osmnode:42 .\n"
-      "osmway:13 ogc:contains osmnode:42 .\n",
+      "osmway:13 ogc:intersects_nonarea osmnode:42 .\n"
+      "osmway:13 ogc:contains_nonarea osmnode:42 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -1960,8 +1960,8 @@ TEST(OSM_GeometryHandler, dumpNodeRelationsSimpleContains) {
                   "                           1 checks performed\n"
                   "                           contains: 1 yes: 1\n"));
   ASSERT_EQ(
-      "osmway:11 ogc:intersects osmnode:42 .\n"
-      "osmway:11 ogc:contains osmnode:42 .\n",
+      "osmway:11 ogc:intersects_nonarea osmnode:42 .\n"
+      "osmway:11 ogc:contains_nonarea osmnode:42 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -2249,9 +2249,9 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleIntersects) {
                   "                           contains: 3 contains envelope: 1 "
                   "yes: 1\n"));
   ASSERT_EQ(
-      "osmway:11 ogc:intersects osmway:42 .\n"
-      "osmway:13 ogc:intersects osmway:42 .\n"
-      "osmway:12 ogc:contains osmway:42 .\n",
+      "osmway:11 ogc:intersects_nonarea osmway:42 .\n"
+      "osmway:13 ogc:intersects_nonarea osmway:42 .\n"
+      "osmway:12 ogc:contains_nonarea osmway:42 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -2370,8 +2370,8 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleContains) {
                   "                           contains: 1 contains envelope: 1 "
                   "yes: 1\n"));
   ASSERT_EQ(
-      "osmway:11 ogc:intersects osmway:42 .\n"
-      "osmway:11 ogc:contains osmway:42 .\n",
+      "osmway:11 ogc:intersects_nonarea osmway:42 .\n"
+      "osmway:11 ogc:contains_nonarea osmway:42 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -2503,16 +2503,16 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleIntersectsWithNodeInfo) {
                   "skipped by DAG\n"
                   "                           contains: 3 contains envelope: 1 "
                   "yes: 1\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmway:13 ogc:intersects osmnode:1 .\n"
-                                   "osmway:13 ogc:contains osmnode:1 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmway:11 ogc:intersects osmnode:2 .\n"
-                                   "osmway:11 ogc:contains osmnode:2 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmway:11 ogc:intersects osmway:42 .\n"
-                                   "osmway:13 ogc:intersects osmway:42 .\n"
-                                   "osmway:12 ogc:contains osmway:42 .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osmway:13 ogc:intersects_nonarea osmnode:1 .\n"
+                               "osmway:13 ogc:contains_nonarea osmnode:1 .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osmway:11 ogc:intersects_nonarea osmnode:2 .\n"
+                               "osmway:11 ogc:contains_nonarea osmnode:2 .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osmway:11 ogc:intersects_nonarea osmway:42 .\n"
+                               "osmway:13 ogc:intersects_nonarea osmway:42 .\n"
+                               "osmway:12 ogc:contains_nonarea osmway:42 .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -2638,12 +2638,12 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleContainsWithNodeInfo) {
                   "skipped by DAG\n"
                   "                           contains: 1 contains envelope: 1 "
                   "yes: 1\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmway:11 ogc:intersects osmnode:2 .\n"
-                                   "osmway:11 ogc:contains osmnode:2 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmway:11 ogc:intersects osmway:42 .\n"
-                                   "osmway:11 ogc:contains osmway:42 .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osmway:11 ogc:intersects_nonarea osmnode:2 .\n"
+                               "osmway:11 ogc:contains_nonarea osmnode:2 .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osmway:11 ogc:intersects_nonarea osmway:42 .\n"
+                               "osmway:11 ogc:contains_nonarea osmway:42 .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);


### PR DESCRIPTION
Changes name of predicate to better reflect that ogc:contains/ogc:intersects is only between area and nonarea objects.

Remove --add-inverse-relation-direction
contains -> contains_nonarea
intersects -> intersects_nonarea