### PR TITLE
Added metadata triple for new --iri-prefix-for-untagged-nodes option

### DIFF
--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -400,7 +400,7 @@ void osm2rdf::ttl::Writer<T>::writeMetadata() {
                     generateBooleanLiteral(!_config.addUntaggedAreas));
   writeOptionTriple(
       osm2rdf::config::constants::IRI_PREFIX_FOR_UNTAGGED_NODES_OPTION_LONG,
-      _config.iriPrefixForUntaggedNodes);
+      generateLiteral(_config.iriPrefixForUntaggedNodes));
 
   _out->flush();
 }


### PR DESCRIPTION
Added metadata triple that stores the IRI prefix for untagged nodes that can be declared with the new --iri-prefix-for-untagged-nodes option