### PR TITLE
Separate reader for node/way/area and relation to fix missing relation geometries

### DIFF
--- a/include/osm2rdf/osm/OsmiumHandler.h
+++ b/include/osm2rdf/osm/OsmiumHandler.h
@@ -88,6 +88,8 @@ class OsmiumHandler : public osmium::handler::Handler {
   void handleBuffers(
       osmium::memory::Buffer& buffer,
       osmium::area::MultipolygonManager<osmium::area::Assembler>& mp_manager);
+  void handleRelBuffers(
+      osmium::memory::Buffer& buffer);
   void handleAreaBuffers(osmium::memory::Buffer& areaBuffer);
 };
 }  // namespace osm2rdf::osm

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -160,6 +160,16 @@ void osm2rdf::osm::FactHandler<W>::area(const osm2rdf::osm::Area& area) {
   _writer->writeLiteralTripleUnsafe(
       subj, _areaIRI, ::util::formatFloat(area.geomArea(), AREA_PRECISION),
       _iriXSDDouble);
+
+  if (!area.fromWay()) {
+    // for areas from relations, always write hasCompleteGeometry true for
+    // consistency with non-area relations
+    _writer->writeTriple(
+        subj,
+        _writer->generateIRIUnsafe(NAMESPACE__OSM2RDF, "hasCompleteGeometry"),
+            osm2rdf::ttl::constants::LITERAL__TRUE
+            );
+  }
 }
 
 // ____________________________________________________________________________

--- a/src/osm/Way.cpp
+++ b/src/osm/Way.cpp
@@ -19,6 +19,8 @@
 
 #include "osm2rdf/osm/Way.h"
 
+#include <osmium/tags/taglist.hpp>
+#include <osmium/tags/tags_filter.hpp>
 #include <vector>
 
 #include "osm2rdf/osm/Box.h"
@@ -104,6 +106,13 @@ bool osm2rdf::osm::Way::isArea() const noexcept {
   if (!closed()) {
     return false;
   }
-  auto areaTag = _w->tags()["area"];
-  return areaTag == nullptr || strcmp(areaTag, "no") != 0;
+  if (_w->tags().has_tag("area", "no")) {
+    return false;
+  }
+
+  if (osmium::tags::match_none_of(_w->tags(), osmium::TagsFilter{true})) {
+    return false;
+  }
+
+  return true;
 }

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -131,7 +131,8 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
       "osmrel:10 geo:hasGeometry osm2rdfgeom:osmrel_10 "
       ".\nosm2rdfgeom:osmrel_10 geo:asWKT \"POLYGON((48 7.5,48 "
       "7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 "
-      "osm2rdf:area \"0.01\"^^xsd:double .\n",
+      "osm2rdf:area \"0.01\"^^xsd:double .\nosmrel:10 "
+      "osm2rdf:hasCompleteGeometry \"true\"^^xsd:boolean .\n",
       buffer.str());
 
   // Cleanup

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -162,7 +162,7 @@ TEST(OSM_FactHandler, areaFromRelation) {
       "7.5,48.1 7.5,48.1 7.6,48 7.6,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 "
       "osm2rdfgeom:obb \"POLYGON((48.1 7.5,48.1 7.6,48 7.6,48 7.5,48.1 "
       "7.5))\"^^geo:wktLiteral .\nosmrel:10 osm2rdf:area \"0.01\"^^xsd:double "
-      ".\n",
+      ".\nosmrel:10 osm2rdf:hasCompleteGeometry \"true\"^^xsd:boolean .\n",
       buffer.str());
 
   // Cleanup

--- a/tests/osm/Way.cpp
+++ b/tests/osm/Way.cpp
@@ -200,7 +200,7 @@ TEST(OSM_Way, isAreaFalseForOpenWay) {
 }
 
 // ____________________________________________________________________________
-TEST(OSM_Way, isAreaTrueForTriangle) {
+TEST(OSM_Way, isAreaFalseForTriangleWithoutTags) {
   // Create osmium object
   const size_t initial_buffer_size = 10000;
   osmium::memory::Buffer buffer{initial_buffer_size,
@@ -215,6 +215,28 @@ TEST(OSM_Way, isAreaTrueForTriangle) {
 
   // Create osm2rdf object from osmium object
   osm2rdf::osm::Way w{buffer.get<osmium::Way>(0)};
+  ASSERT_TRUE(w.closed());
+
+  ASSERT_FALSE(w.isArea());
+}
+
+// ____________________________________________________________________________
+TEST(OSM_Way, isAreaFTrueForTriangleWithTags) {
+  // Create osmium object
+  const size_t initial_buffer_size = 10000;
+  osmium::memory::Buffer buffer{initial_buffer_size,
+                                osmium::memory::Buffer::auto_grow::yes};
+  osmium::builder::add_way(buffer, osmium::builder::attr::_id(42),
+                           osmium::builder::attr::_nodes({
+                               {1, {48.0, 7.51}},
+                               {2, {48.0, 7.61}},
+                               {1, {48.1, 7.61}},
+                               {1, {48.0, 7.51}},
+                           }),
+                           osmium::builder::attr::_tag("some", "tag"));
+
+  // Create osm2rdf object from osmium object
+  const osm2rdf::osm::Way w{buffer.get<osmium::Way>(0)};
   ASSERT_TRUE(w.closed());
 
   ASSERT_TRUE(w.isArea());


### PR DESCRIPTION
Adds separate readers for `nwa` (node/way/area) and `relation` to fix an issue where way member geometries may not have been seen at the time a relation arrives at the RelationHandler when using multiple threads.

Fixes #128.

On the side, add `hasCompleteGeometry true` triples to relation areas for consistency (because the same triple is present for non-area relations) (fixes #130), and fix a subtle issue with the area classification for ways. Because of this issue, untagged closed ways (of which there are few, if any, in OSM) had no geometry object. Fixes #131, see there for details.